### PR TITLE
Dirty Fix: Disable IPv6

### DIFF
--- a/moabdb/core.py
+++ b/moabdb/core.py
@@ -39,7 +39,6 @@ from .lib import _check_access, _server_req
 from .constants import pd, Union, cf
 
 
-
 def get_equity(tickers: Union[str, list],
                sample: str = "1m",
                start: str = None,
@@ -335,7 +334,7 @@ def get_rates(sample: str = "1y",
     # Check authorization
     if not _check_access():
         raise errors.MoabRequestError(
-            "Premium datasets needs API credentials, see moabdb.com")
+            "Premium datasets need API credentials, see moabdb.com")
 
     # String time to integer time
     start_tm, end_tm = timewindows.get_unix_dates(sample, start, end)

--- a/moabdb/proto_wrapper.py
+++ b/moabdb/proto_wrapper.py
@@ -7,6 +7,12 @@ import requests
 from .protocol_pb2 import Request as _Req, Response as _Response
 from . import errors
 
+# IPv6 address takes about 180 seconds to connect
+# Dirty fix until a proper investigation is done
+# Might break other code the user runs if connecting to IPv6
+# pylint: disable=no-member
+requests.packages.urllib3.util.connection.HAS_IPV6 = False
+
 REQUEST = _Req
 RESPONSE = _Response
 


### PR DESCRIPTION
This code will fix MoabDB for clients that are behind IPv6 addresses.

Many new internet connections are set up with both IPv6 and IPv4. For whatever reason, the server takes a solid 150ish seconds to respond to requests on the IPv6 interface. This fix tells requests that IPv6 isn't an option and to choose the IPv4 endpoint address.

This has the possibility of slowing down/possibly breaking other code the user runs. I doubt this will be a huge problem, as most clients/servers still have an IPv4 endpoint.